### PR TITLE
コネクションエラー周りのハンドリング

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,19 +1,35 @@
 (function() {
-  var Client, _managers,
+  var Client, _connection_errors, _managers,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   _managers = {};
 
+  _connection_errors = {};
+
   Client = (function() {
     function Client(io_or_socket, options, cb) {
-      var path, uri;
+      var path, self, uri;
       if (options == null) {
         options = {};
+      }
+      if (cb == null) {
+        cb = null;
       }
       this.url = options.url || '';
       this.name_space = options.name_space || '__';
       this._socket = io_or_socket;
       this._joined = [];
+      this._connection_error = _connection_errors[this.url];
+      if (this._connection_error) {
+        if (cb) {
+          setTimeout((function(_this) {
+            return function() {
+              return cb(_this._connection_error);
+            };
+          })(this), 0);
+        }
+        return;
+      }
       if (io_or_socket.Manager != null) {
         path = '/' + this.name_space;
         uri = this.url;
@@ -38,16 +54,24 @@
       } else if (io_or_socket.constructor.name !== 'Socket') {
         this._socket = io_or_socket.connect(this.url + '/' + this.name_space, options.connect_options || {});
       }
-      if (!cb) {
-        return;
-      }
+      self = this;
       this._socket.on('connection_ack', function(data) {
+        var _connection_error;
         if (data.error) {
-          return cb(data.error);
+          _connection_errors[self.url] = new Error(data.message);
+          _connection_errors[self.url].name = data.name;
+          self._connection_error = _connection_errors[self.url];
+          if (cb) {
+            cb(self._connection_error);
+          }
+          return;
         }
-        return cb(null, {
-          success: true
-        });
+        _connection_error = null;
+        if (cb) {
+          cb(null, {
+            success: true
+          });
+        }
       });
     }
 
@@ -93,6 +117,9 @@
       }
       if (cb == null) {
         cb = function() {};
+      }
+      if (this._connection_error) {
+        return cb.apply(this, [this._connection_error]);
       }
       ack_cb = function() {
         return cb.apply(this, arguments);

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,8 +19,9 @@
       this.name_space = options.name_space || '__';
       this._socket = io_or_socket;
       this._joined = [];
-      this._connection_error = _connection_errors[this.url];
-      if (this._connection_error) {
+      this._connection_error = null;
+      if ((io_or_socket.Manager != null) && _connection_errors[this.url]) {
+        this._connection_error = _connection_errors[this.url];
         if (cb) {
           setTimeout((function(_this) {
             return function() {
@@ -54,9 +55,16 @@
       } else if (io_or_socket.constructor.name !== 'Socket') {
         this._socket = io_or_socket.connect(this.url + '/' + this.name_space, options.connect_options || {});
       }
+      if ((io_or_socket.Manager != null) && this.url in _connection_errors) {
+        if (cb) {
+          cb(null, {
+            success: true
+          });
+        }
+        return;
+      }
       self = this;
       this._socket.on('connection_ack', function(data) {
-        var _connection_error;
         if (data.error) {
           _connection_errors[self.url] = new Error(data.message);
           _connection_errors[self.url].name = data.name;
@@ -66,7 +74,7 @@
           }
           return;
         }
-        _connection_error = null;
+        _connection_errors[self.url] = null;
         if (cb) {
           cb(null, {
             success: true

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,6 +106,7 @@
                 message: err.message,
                 name: err.name
               });
+              socket.disconnect(true);
               return;
             }
             _this._listen(socket);

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -50,7 +50,7 @@ class Client
       @_socket = io_or_socket.connect @url + '/' + @name_space, options.connect_options || {}
 
     # not error, but connection acked
-    if io_or_socket.Manager? and url of _connection_errors
+    if io_or_socket.Manager? and @url of _connection_errors
       cb null, {success: true} if cb
       return
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,6 +1,6 @@
 
 _managers = {} # for socket.io-client >= 1.4.x
-_connection_errors = {}
+_connectionErrors = {}
 
 class Client
   constructor: (io_or_socket, options={}, cb=null) ->
@@ -13,15 +13,16 @@ class Client
 
     @_joined = []
 
-    @_connection_error = null
+    @_connectionError = null
 
-    if io_or_socket.Manager? and _connection_errors[@url]
 
-      @_connection_error = _connection_errors[@url]
+    if io_or_socket.Manager? and _connectionErrors[@url]
+
+      @_connectionError = _connectionErrors[@url]
 
       if cb
         setTimeout =>
-          cb @_connection_error
+          cb @_connectionError
         , 0
       return
 
@@ -50,7 +51,7 @@ class Client
       @_socket = io_or_socket.connect @url + '/' + @name_space, options.connect_options || {}
 
     # not error, but connection acked
-    if io_or_socket.Manager? and @url of _connection_errors
+    if io_or_socket.Manager? and @url of _connectionErrors
       cb null, {success: true} if cb
       return
 
@@ -60,16 +61,16 @@ class Client
 
       if data.error
 
-        _connection_errors[self.url] = new Error(data.message)
-        _connection_errors[self.url].name = data.name
-        self._connection_error = _connection_errors[self.url]
+        _connectionErrors[self.url] = new Error(data.message)
+        _connectionErrors[self.url].name = data.name
+        self._connectionError = _connectionErrors[self.url]
 
-        cb self._connection_error if cb
+        cb self._connectionError if cb
 
         return
 
       # connection success
-      _connection_errors[self.url] = null
+      _connectionErrors[self.url] = null
 
       cb null, {success: true} if cb
 
@@ -100,8 +101,8 @@ class Client
 
   _send: (method, args=[], cb=()->) ->
 
-    if @_connection_error
-      return cb.apply(@, [@_connection_error])
+    if @_connectionError
+      return cb.apply(@, [@_connectionError])
 
     ack_cb = () ->
       return cb.apply(@, arguments)

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -13,9 +13,12 @@ class Client
 
     @_joined = []
 
-    @_connection_error = _connection_errors[@url]
+    @_connection_error = null
 
-    if @_connection_error
+    if io_or_socket.Manager? and _connection_errors[@url]
+
+      @_connection_error = _connection_errors[@url]
+
       if cb
         setTimeout =>
           cb @_connection_error
@@ -46,6 +49,11 @@ class Client
     else if (io_or_socket.constructor.name isnt 'Socket')
       @_socket = io_or_socket.connect @url + '/' + @name_space, options.connect_options || {}
 
+    # not error, but connection acked
+    if io_or_socket.Manager? and url of _connection_errors
+      cb null, {success: true} if cb
+      return
+
     self = @
 
     @_socket.on 'connection_ack', (data) ->
@@ -60,7 +68,8 @@ class Client
 
         return
 
-      _connection_error = null
+      # connection success
+      _connection_errors[self.url] = null
 
       cb null, {success: true} if cb
 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -92,6 +92,8 @@ class Server
 
           socket.emit 'connection_ack', {error: true, message: err.message, name: err.name}
 
+          socket.disconnect(true)
+
           return
 
         @_listen(socket)


### PR DESCRIPTION
refs #10 

connectイベントはsocketが確立した時に発生するイベントだが、socketがMinimumRPC Client間で使いまわされることから、回線確立後に作成されたClientからはイベントが発生しないようにみえる。

イベントはurl毎に発生するので、接続確立の可否・エラーについて、url毎に保持して共有するようにした。