### PR TITLE
emitがロストするケースへの対応

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,9 @@
       this.name_space = options.name_space || '__';
       this._socket = io_or_socket;
       this._joined = [];
+      this._requestId = 1;
+      this._requestCache = {};
+      this._disconnected = true;
       if (io_or_socket.Manager != null) {
         path = '/' + this.name_space;
         uri = this.url;
@@ -22,15 +25,34 @@
         }
         this._manager = _managers[uri];
         this._socket = this._manager.socket(path);
+        this._socket.on('connect', (function(_this) {
+          return function() {
+            return _this._disconnected = false;
+          };
+        })(this));
+        this._socket.on('disconnect', (function(_this) {
+          return function() {
+            return _this._disconnected = true;
+          };
+        })(this));
         this._socket.on('reconnect', (function(_this) {
           return function() {
-            var joined, room, _i, _len, _results;
+            var ack_cb, err, joined, k, req, room, _i, _len, _ref, _ref1, _results;
+            _this._disconnected = false;
             joined = _this._joined;
             _this._joined = [];
-            _results = [];
             for (_i = 0, _len = joined.length; _i < _len; _i++) {
               room = joined[_i];
-              _results.push(_this.join(room));
+              _this.join(room);
+            }
+            _ref = _this._requestCache;
+            _results = [];
+            for (k in _ref) {
+              req = _ref[k];
+              _ref1 = req, req = _ref1.req, ack_cb = _ref1.ack_cb;
+              err = new Error('There is no chance of getting a response by the request');
+              err.name = 'ResponseError';
+              _results.push(ack_cb(err));
             }
             return _results;
           };
@@ -87,21 +109,32 @@
     };
 
     Client.prototype._send = function(method, args, cb) {
-      var ack_cb, req;
+      var ack_cb, req, requestId, self;
       if (args == null) {
         args = [];
       }
       if (cb == null) {
         cb = function() {};
       }
+      requestId = this._requestId++;
+      self = this;
       ack_cb = function() {
-        return cb.apply(this, arguments);
+        cb.apply(this, arguments);
+        if (self._requestCache[requestId]) {
+          delete self._requestCache[requestId];
+        }
       };
       req = {
         method: method,
         args: args
       };
-      return this._socket.emit('apply', req, ack_cb);
+      this._socket.emit('apply', req, ack_cb);
+      if (!this._disconnected) {
+        return this._requestCache[requestId] = {
+          req: req,
+          ack_cb: ack_cb
+        };
+      }
     };
 
     return Client;

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -45,7 +45,12 @@ class Client
 
           {req, ack_cb} = req
 
-          @_socket.emit 'apply', req, ack_cb
+          # リクエストの成否が不明なので再実行するべきではない(?)
+          # @_socket.emit 'apply', req, ack_cb
+
+          err = new Error('There is no chance of getting a response by the request')
+          err.name = 'ResponseError'
+          ack_cb err
 
     else if (io_or_socket.constructor.name isnt 'Socket')
       @_socket = io_or_socket.connect @url + '/' + @name_space, options.connect_options || {}

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -128,7 +128,7 @@ describe 'reconnect', ->
         assert event.val
         if reconnected
           assert event.reconnected
-          done()
+          app.close(done)
 
       setTimeout =>
         @server.channel.to('reconnect_test').emit 'test', {val: true}

--- a/test/reconnection.coffee
+++ b/test/reconnection.coffee
@@ -69,6 +69,9 @@ describe 'reconnect', ->
         cnt++
         console.log('okokok', err, n, cnt)
 
+        assert cnt is 3
+        done()
+
     client._socket.on 'reconnect', ->
       console.log('reconnect')
 
@@ -81,9 +84,6 @@ describe 'reconnect', ->
 
         console.log('call delayMethod method 2 (lost)')
         client.send 'delayMethod', 2, (err) ->
-          console.log 'can not call'
+          assert err.name is 'ResponseError'
           console.log('okok', err, n, cnt)
           cnt++
-
-          assert cnt is 3
-          done()

--- a/test/reconnection.coffee
+++ b/test/reconnection.coffee
@@ -1,0 +1,89 @@
+assert = require("assert")
+io_for_client = require('socket.io-client')
+Server = require('../src/server')
+Client = require('../src/client')
+
+
+_server = (port=2000, cb) -> 
+  app = require("http").createServer()
+  io = require("socket.io")(app)
+  server = new Server(io)
+  app.listen port, () ->
+    cb null, app, io, server
+  return server
+
+_client = (port=2000) ->
+  return new Client io_for_client, {
+    url: 'http://localhost:'+port
+  }
+
+
+describe 'reconnect', ->
+
+  _build = (n, cb=null) ->
+    # delayMethod, returnError, restartを持つサーバを作る
+    console.log('server: build server', n)
+    @server = _server 2001, (err, @app, @io, @server) =>
+      @num = n
+      console.log('server: listen start')
+      cb?()
+    @server.set 'delayMethod', (n, cb) ->
+      console.log('server: delay method start', n)
+      setTimeout ->
+        console.log('server: delay method done', n)
+        cb null, n
+      , 100
+    @server.set 'restart', (cb) =>
+      console.log('server: call restart')
+      cb()
+
+      # 回線をクローズし、同様のサーバを作り直す
+      console.log('server: close connection')
+      console.log(@num)
+      @app.close()
+      setTimeout =>
+        console.log('server: restart server', n+1)
+        _build.call @, n+1
+      , 100
+
+  before (done) ->
+    _build.call @, 0, done
+
+  after (done) ->
+    if @app
+      @app.close(done) 
+    else
+      done()
+
+  it 'can reconnect', (done) ->
+    client = _client(2001)
+
+    cnt = 0
+
+    client._socket.on 'disconnect', ->
+      console.log('disconnect')
+
+      # disconnect発覚直後に実行されたイベントはreconnect後に実行される
+      console.log('call delayMethod method 3')
+      client.send 'delayMethod', 3, (err, n) ->
+        cnt++
+        console.log('okokok', err, n, cnt)
+
+    client._socket.on 'reconnect', ->
+      console.log('reconnect')
+
+    console.log('call delayMethod method 1')
+    client.send 'delayMethod', 1, (err, n) ->
+      cnt++
+      console.log('ok', err, n)
+
+      client.send 'restart', ->
+
+        console.log('call delayMethod method 2 (lost)')
+        client.send 'delayMethod', 2, (err) ->
+          console.log 'can not call'
+          console.log('okok', err, n, cnt)
+          cnt++
+
+          assert cnt is 3
+          done()


### PR DESCRIPTION
refs #12 
socket clientは、

* disconnectであると把握している場合はemitを保留する
* connectedであると思っている間、実態はどうであれemitは実行される
* emitの完了(成否)を把握していない

つまり、クライアント側がconnectedであると思っているときにサーバ側が落ちていると、その間のemitはロストする。

reconnectイベントが発生する状況ではack_cbが返ってくる見込みはないので、ack_cbにResponseErrorを返すようにし、処理待ちで固まるのを防ぐ。