### PR TITLE
emit待ち状態に関する判定の修正

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -44,7 +44,15 @@
         this._socket = this._manager.socket(path);
         this._socket.on('connect', (function(_this) {
           return function() {
-            return _this._disconnected = false;
+            var k, req, _ref, _results;
+            _this._disconnected = false;
+            _ref = _this._requestCache;
+            _results = [];
+            for (k in _ref) {
+              req = _ref[k];
+              _results.push(req.queued = false);
+            }
+            return _results;
           };
         })(this));
         this._socket.on('disconnect', (function(_this) {
@@ -54,7 +62,7 @@
         })(this));
         this._socket.on('reconnect', (function(_this) {
           return function() {
-            var ack_cb, err, joined, k, req, room, _i, _len, _ref, _ref1, _results;
+            var ack_cb, err, joined, k, queued, req, room, _i, _len, _ref, _results;
             _this._disconnected = false;
             joined = _this._joined;
             _this._joined = [];
@@ -66,7 +74,10 @@
             _results = [];
             for (k in _ref) {
               req = _ref[k];
-              _ref1 = req, req = _ref1.req, ack_cb = _ref1.ack_cb;
+              ack_cb = req.ack_cb, queued = req.queued;
+              if (queued) {
+                continue;
+              }
               err = new Error('There is no chance of getting a response by the request');
               err.name = 'ResponseError';
               _results.push(ack_cb(err));
@@ -155,21 +166,17 @@
       self = this;
       ack_cb = function() {
         cb.apply(this, arguments);
-        if (self._requestCache[requestId]) {
-          delete self._requestCache[requestId];
-        }
+        delete self._requestCache[requestId];
       };
       req = {
         method: method,
         args: args
       };
       this._socket.emit('apply', req, ack_cb);
-      if (!this._disconnected) {
-        return this._requestCache[requestId] = {
-          req: req,
-          ack_cb: ack_cb
-        };
-      }
+      return this._requestCache[requestId] = {
+        ack_cb: ack_cb,
+        queued: this._disconnected
+      };
     };
 
     return Client;

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -133,7 +133,7 @@ class Client
     ack_cb = () ->
       cb.apply(@, arguments)
 
-      delete self._requestCache[requestId] if self._requestCache[requestId]
+      delete self._requestCache[requestId]
 
       return
 

--- a/test/reconnection.coffee
+++ b/test/reconnection.coffee
@@ -69,6 +69,7 @@ describe 'reconnect', ->
         cnt++
         console.log('okokok', err, n, cnt)
 
+        assert not err
         assert cnt is 3
         done()
 


### PR DESCRIPTION
refs #14 

1. 切断、disconnect発生
2. リクエスト発生
   * socket.ioがdisconnectであることを知っており、emitが保留状態になる
   * *この場合はrequestCacheにack_cbを保存しない*（現状の実装）
3. 再接続、reconnect => connectとなり、emitが実行される
4. *ここで再度切断*
5. disconnect => reconnect => connect
   * emit保留状態の場合、ack_cbが保存されていないのでerrorが返らない

上の状態になっていたので、修正しました。

* emit保留状態かどうかをrequestCacheに含めるようにした
* emit保留状態であればすぐにはerrを返さない
* connectされた時に、requestCacheのフラグを変更
   * => 再度切断されたときも、エラーを返せるようになる


